### PR TITLE
Add LambdaLayer

### DIFF
--- a/fei-modelzoo.cabal
+++ b/fei-modelzoo.cabal
@@ -1,6 +1,6 @@
 cabal-version:              2.4
 name:                       fei-modelzoo
-version:                    1.1.0
+version:                    2.0.0
 synopsis:                   A collection of standard models
 description:                A collection of standard models
 homepage:                   http://github.com/pierric/fei-modelzoo
@@ -17,6 +17,7 @@ Library
                             MXNet.NN.ModelZoo.VGG
                             MXNet.NN.ModelZoo.Resnet
                             MXNet.NN.ModelZoo.Resnext
+                            MXNet.NN.ModelZoo.LambdaLayer
                             MXNet.NN.ModelZoo.RCNN.FPN
                             MXNet.NN.ModelZoo.RCNN.RCNN
                             MXNet.NN.ModelZoo.RCNN.MaskRCNN
@@ -28,7 +29,6 @@ Library
                             TypeFamilies,
                             OverloadedLabels,
                             OverloadedStrings,
-                            OverloadedLists,
                             FlexibleContexts,
                             FlexibleInstances,
                             StandaloneDeriving,
@@ -56,3 +56,18 @@ Library
                           , fei-base >= 2.0.0
                           , fei-nn >= 2.0.0
                           , fei-einops >= 0.1.0
+
+test-suite model-test
+  type:                     exitcode-stdio-1.0
+  hs-source-dirs:           test
+  main-is:                  TestMain.hs
+  other-modules:            TestLambdaLayer
+  build-depends:            rio
+                          , base
+                          , tasty
+                          , tasty-hunit
+                          , tasty-discover
+                          , fei-base >= 2.0.0
+                          , fei-nn >= 2.0.0
+                          , fei-modelzoo >= 2.0.0
+  default-language:         Haskell2010

--- a/src/MXNet/NN/ModelZoo/LambdaLayer.hs
+++ b/src/MXNet/NN/ModelZoo/LambdaLayer.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE ExplicitForAll      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module MXNet.NN.ModelZoo.LambdaLayer where
+
+import           RIO
+
+import           Fei.Einops
+import           MXNet.Base
+import           MXNet.NN.Layer
+
+-- | The LambdaNetworks' layer
+lambdaLayer :: forall a . NumericDType a
+            => Int -- ^ output dimension
+            -> Int -- ^ key dimension
+            -> Int -- ^ intra-depth dimension
+            -> Int -- ^ number of heads
+            -> Int -- ^ receptive window, max of height and width of the input feature
+            -> Symbol a -- ^ input feature
+            -> Layer (Symbol a)
+lambdaLayer dim_out dim_k dim_u heads window x
+  | dim_out `mod` heads /= 0 = error "dim_out must be divisible by heads"
+  | otherwise = do
+      let dim_v  = dim_out `div` heads
+      _q <- convolution (#data := x .& #kernel := [1,1] .& #num_filter := dim_k * heads .& #no_bias := True .& Nil)
+      _k <- convolution (#data := x .& #kernel := [1,1] .& #num_filter := dim_k * dim_u .& #no_bias := True .& Nil)
+      _v <- convolution (#data := x .& #kernel := [1,1] .& #num_filter := dim_v * dim_u .& #no_bias := True .& Nil)
+
+      _q <- sequential "_q" $ rearrange _q "b (h k) hh ww -> b h k (hh ww)" [#h .== heads]
+      _k <- sequential "_k" $ rearrange _k "b (u k) hh ww -> b u k (hh ww)" [#u .== dim_u]
+      _v <- sequential "_v" $ rearrange _v "b (u v) hh ww -> b u v (hh ww)" [#u .== dim_u, #v .== dim_v]
+
+      _k <- softmax (#data := _k .& #axis := (-1) .& Nil)
+
+      λc <- einsum "b u k m, b u v m -> b k v" [_k, _v] False
+      υc <- einsum "b h k n, b k v -> b h v n" [_q, λc] False
+
+      rel_pos_emb <- parameter "rel_pos_emb" ReqWrite (Just [2 * window - 1, 2 * window - 1, dim_k, dim_u])
+      rel_pos     <- calcRelPos @a window
+      rel_pos_lku <- gather rel_pos_emb rel_pos
+
+      λp <- einsum "n m k u, b u v m -> b n k v" [rel_pos_lku, _v] False
+      υp <- einsum "b h k n, b n k v -> b h v n" [_q, λp] False
+
+      _υ <- add_ υc υp
+      _υ <- rearrange _υ "b h v hhww -> b (h v) hhww" []
+      reshapeLike _υ (Just (-1)) Nothing x (Just (-2)) Nothing
+
+-- | Calculate the relative distance of every pair of points on a grid of size 'n', (2, n*n, n*n)
+calcRelPos :: forall a t . (HasCallStack, PrimTensorOp t, MXTensor t, NumericDType a)
+           => Int -> TensorMonad t (t a)
+calcRelPos n = do
+    r <- arange Proxy 0 (Just $ fromIntegral n) Nothing
+    grid_x <- expandDims 1 r >>= broadcastAxis [1] [n]
+    grid_y <- expandDims 0 r >>= broadcastAxis [0] [n]
+    mesh   <- stack 0 [grid_x, grid_y]
+    mesh   <- rearrange mesh "n i j -> n (i j)" []
+    ypos   <- expandDims 1 mesh
+    xpos   <- expandDims 2 mesh
+    sub_ ypos xpos >>= addScalar (fromIntegral $ n - 1)

--- a/src/MXNet/NN/ModelZoo/RCNN/FPN.hs
+++ b/src/MXNet/NN/ModelZoo/RCNN/FPN.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 module MXNet.NN.ModelZoo.RCNN.FPN where
 
 import           RIO

--- a/src/MXNet/NN/ModelZoo/RCNN/FasterRCNN.hs
+++ b/src/MXNet/NN/ModelZoo/RCNN/FasterRCNN.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 module MXNet.NN.ModelZoo.RCNN.FasterRCNN where

--- a/src/MXNet/NN/ModelZoo/RCNN/MaskRCNN.hs
+++ b/src/MXNet/NN/ModelZoo/RCNN/MaskRCNN.hs
@@ -20,7 +20,7 @@ data MaskRCNN a
       , _masks              :: Symbol a
       }
 
-maskHead :: NumericDType a => Symbol a -> Int -> Int -> Int -> Int -> Layer (Symbol a)
+maskHead :: FloatDType a => Symbol a -> Int -> Int -> Int -> Int -> Layer (Symbol a)
 maskHead top_feat num_fcn_conv num_fg_classes batch_size num_mask_channels = do
     -- top_feat: The network input tensor of shape (B * N, fC, fH, fW).
     --
@@ -52,7 +52,7 @@ maskHead top_feat num_fcn_conv num_fg_classes batch_size num_mask_channels = do
             unique' $ activation (#data := x .& #act_type := #relu .& Nil)
 
 
-graphT :: NumericDType a
+graphT :: FloatDType a
        => FasterRCNN.RcnnConfiguration -> Layer (MaskRCNN a, Symbol a)
 graphT conf@(FasterRCNN.RcnnConfigurationTrain{..}) = do
     gt_masks <- variable "gt_masks"
@@ -117,7 +117,7 @@ graphT conf@(FasterRCNN.RcnnConfigurationTrain{..}) = do
                 _masks_loss = masks_loss
             }, result_sym)
 
-graphI :: NumericDType a
+graphI :: FloatDType a
        => FasterRCNN.RcnnConfiguration -> Layer (MaskRCNN a, Symbol a)
 graphI conf@(FasterRCNN.RcnnConfigurationInference{..}) = do
     (fr@FasterRCNN.FasterRCNNInferenceOnly{..}, fr_outputs) <- FasterRCNN.graphI conf

--- a/src/MXNet/NN/ModelZoo/Resnet.hs
+++ b/src/MXNet/NN/ModelZoo/Resnet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 module MXNet.NN.ModelZoo.Resnet where
 
 import           Data.Typeable  (Typeable)
@@ -8,8 +9,9 @@ import qualified RIO.NonEmpty   as RNE
 import           MXNet.Base
 import           MXNet.NN.Layer
 
-data NoKnownExperiment = NoKnownExperiment Int
-    deriving (Typeable, Show)
+data NoKnownExperiment
+  = NoKnownExperiment Int
+  deriving (Show, Typeable)
 instance Exception NoKnownExperiment
 
 -------------------------------------------------------------------------------

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # GHC 8.0.2 has a bug, which may leads to OOM
 # https://ghc.haskell.org/trac/ghc/ticket/13615
-resolver: lts-17.2
+resolver: lts-14.27
 packages:
 - .
 - ../fei-einops
@@ -8,18 +8,21 @@ packages:
 - ../fei-base
 - ../tuple-ops
 extra-deps:
+- type-sets-0.1.1.0
+- cmptype-0.2.0.0
+- magic-tyfams-0.1.1.0
 - git: https://github.com/0xCM/type-combinators.git
   commit: 58167dd4017b666ff592bb9493b0570a054aabdb
 - git: https://github.com/pierric/haskell-src-exts.git
   commit: 792ec73bc3b0e8d4aa2683af6b2a3fc03b5f8d95
 extra-include-dirs:
-- /home/jiasen/workspace/mxnet/build-1.6.0/include
+- /home/jiasen/workspace/mxnet/build-1.8.0/include
 extra-lib-dirs:
-- /home/jiasen/workspace/mxnet/build-1.6.0
+- /home/jiasen/workspace/mxnet/build-1.8.0
 flags:
   fei-base:
-    mxnet_geq_10700: true
+    mxnet_geq_10800: true
   fei-nn:
-    mxnet_geq_10700: true
+    mxnet_geq_10800: true
   fei-einops:
     mxnet: true


### PR DESCRIPTION
This PR adds a (relative position embedding based) layer definition for [lambda-networks](https://github.com/lucidrains/lambda-networks):

```
-- | The LambdaNetworks' layer
lambdaLayer :: forall a . (FloatDType a, InEnum (DTypeName a) BasicFloatDTypes)
            => Int -- ^ output dimension
            -> Int -- ^ key dimension
            -> Int -- ^ intra-depth dimension
            -> Int -- ^ number of heads
            -> Int -- ^ receptive window, max of height and width of the input feature
            -> Symbol a -- ^ input feature
            -> Layer (Symbol a)
```